### PR TITLE
fix small typos in the docs

### DIFF
--- a/templates/pages/usage.twig
+++ b/templates/pages/usage.twig
@@ -47,6 +47,7 @@ The request data in JSON would look like this:
 This is the data that will be encoded into the HUB-3 barcode. The data format
 is defined by the
 [HUB-3 standard](http://www.hub.hr/sites/default/files/2dbc_0.pdf).
+Note that "special characters" like č, ć, ž, š and đ are counted as 2.
 
 | Key                  | Type           | Description                         |
 | -------------------- | -------------- | ----------------------------------- |
@@ -59,7 +60,7 @@ is defined by the
 | > sender.place       | text (27)      | Address (post code and place name)  |
 | **receiver**         | **object**     | **Receiver data**                   |
 | > receiver.name      | text (30)      | Name and surname, or company name   |
-| > receiver.street    | text (30)      | Address (street and number)         |
+| > receiver.street    | text (27)      | Address (street and number)         |
 | > receiver.place     | text (27)      | Address (post code and place name)  |
 | > receiver.iban      | text (21)      | Account number (IBAN)               |
 | > receiver.model     | text (2)       | Payment reference model             |
@@ -102,7 +103,7 @@ A note about receiver _model_ and _reference_:
   of the reference string.
 
 For more details, check out the Croatian Financial Agency's
-[specification](http://www.fina.hr/fgs.axd?id=14625) (PDF, Croatian).
+[specification](http://www.hub.hr/sites/default/files/2dbc_0.pdf) (PDF, Croatian).
 
 The data is validated by a JSON schema which is available
 [here](/schema/hub3.json).


### PR DESCRIPTION
Seems that both `street` and `place` need to be 27 chars at max (street is listed as 30 in [the docs](https://hub3.bigfish.software/api/v1)). Also, it would be good to note in the docs that "special" chars like č, ć, ž, š and đ are counted as 2. (I guess the constraint is counting unicode characters, like `len(value.encode("utf8"))` would in Python).

An example that caused me some trouble (passing my validation in Python and returning 400s from the API):

```
In [1]: len("Prilaz baruna Filipovića 99")
Out[1]: 27

In [2]: len("Prilaz baruna Filipovića 99".encode("utf8"))
Out[2]: 28
```

Also, fixed the link to the HUB 3 spec in the docs that was broken.